### PR TITLE
Second

### DIFF
--- a/src/assemble.c
+++ b/src/assemble.c
@@ -625,15 +625,15 @@ int8_t assemble (char *file)
     writebin (arrs.filebuf, f.bin);
     writesym (arrs.label, f.sym);
     writelst (arrs.filebuf, f.fp, f.lst);
+    closeasmfiles (&f);
     
     if (geterrors()) clean (file);
-
+    
     freefilebuf (arrs.filebuf);
     freealiasarr (arrs.alias);
     freemacroarr (arrs.macro);
     freelabelarr (arrs.label);
     freetokenbufferarray (arrs.tokbufarr);
-    closeasmfiles (&f);
 
     notify ("Done!\n\n");
 

--- a/src/assemble.c
+++ b/src/assemble.c
@@ -625,15 +625,15 @@ int8_t assemble (char *file)
     writebin (arrs.filebuf, f.bin);
     writesym (arrs.label, f.sym);
     writelst (arrs.filebuf, f.fp, f.lst);
-    closeasmfiles (&f);
-    
-    if (geterrors()) clean (file);
-    
+
     freefilebuf (arrs.filebuf);
     freealiasarr (arrs.alias);
     freemacroarr (arrs.macro);
     freelabelarr (arrs.label);
     freetokenbufferarray (arrs.tokbufarr);
+    closeasmfiles (&f);
+    
+    if (geterrors()) clean (file);   
 
     notify ("Done!\n\n");
 


### PR DESCRIPTION
Resolved an issue where laser is unable to remove .bin, .hex .sym, .lst, .obj files when an .asm file fails to assemble. Those files were not closed prior to deleting, thus nothing had been written to the memory to be deleted.